### PR TITLE
Add pid field to dblp-schema

### DIFF
--- a/dblp-schema.js
+++ b/dblp-schema.js
@@ -22,7 +22,8 @@ const genericSchema = [
 const authorSchema = [
   Joi.string(),
   Joi.object().keys({
-    $value: Joi.string(),
+    _value: Joi.string(),
+    pid: Joi.string(),
     aux: Joi.any(),
     bibtex: Joi.any(),
     orcid: Joi.any(),
@@ -125,6 +126,7 @@ const rawJSONSchema = Joi.object().keys({
   dblpperson: Joi.object().keys({
     // optional properties
     name: Joi.string(),
+    pid: Joi.string(),
     n: Joi.string(),
     // required person property
     person: personSchema.required(),

--- a/dblp.js
+++ b/dblp.js
@@ -5,6 +5,12 @@ const request = require('request');
 // Local requests
 const DBLPPerson = require('./dblp-person.js');
 
+const xml2jsOptions = {
+  charkey: '_value',
+  mergeAttrs: true,
+  explicitArray: false,
+}
+
 /**
  * DBLP class
  * It is responsible for requesting the XML file containing
@@ -21,11 +27,6 @@ class DBLP {
   constructor() {
     this.nameBaseURL = 'https://dblp.org/pers/xx/';
     this.pidBaseURL = 'http://dblp.org/pid';
-    this.options = {
-      charkey: '_value',
-      mergeAttrs: true,
-      explicitArray: false,
-    };
   }
 
   /**
@@ -44,7 +45,7 @@ class DBLP {
       const url = this.nameBaseURL + xml;
 
       // Get the data in the url
-      DBLP.get(url, this.options).then((result) => {
+      DBLP.get(url, xml2jsOptions).then((result) => {
         resolve(result);
       }, () => {
         reject(new Error(`[DBLP getByName] Bad request - check requested user name - ${url}`));
@@ -64,7 +65,7 @@ class DBLP {
       const url = `${this.pidBaseURL}/${pid}.xml`;
 
       // Get the data in the url
-      DBLP.get(url, this.options).then((result) => {
+      DBLP.get(url, xml2jsOptions).then((result) => {
         resolve(result);
       }, () => {
         reject(new Error(`[DBLP getByPID] Bad request - check requested PID - ${url}`));
@@ -88,7 +89,7 @@ class DBLP {
       const url = `${this.pidBaseURL}/${pid}.xml`;
 
       // Get the data in the url
-      DBLP.get(url, this.options).then((result) => {
+      DBLP.get(url, xml2jsOptions).then((result) => {
         resolve(result);
       }, () => {
         reject(new Error(`[DBLP getByHomepage] Bad request - check requested homepage - ${url}`));
@@ -107,7 +108,7 @@ class DBLP {
         // Check response status code
         if (response && response.statusCode === 200) {
           // Create parser instance
-          const parser = new xml2js.Parser(parseOptions);
+          const parser = new xml2js.Parser({...xml2jsOptions, ...parseOptions});
 
           // Parse XML
           parser.parseString(body, (parseError, xml) => {


### PR DESCRIPTION
This is not reported in the dblp, however, it is indeed a field that is
being returned from the API and so it needed to be added.

Overwrite dblp options instead of using only them

the charkey '_value' seems to be necessary for the program to work, so,
the default (dblp.options) was changed to a external xml2jsOptions and
used as a base, overriding the specified fields in parseOptions with the
ones from the default configuration ({...xml2jsOptions, ...parseOptions}).
It had to be taken out of the class since the method is static and
static properties in classes aren't fully supported yet.